### PR TITLE
feat(ui): ListHeader 컴포넌트, 스토리북 #24

### DIFF
--- a/shared/ui/src/components/ListHeader/index.tsx
+++ b/shared/ui/src/components/ListHeader/index.tsx
@@ -1,0 +1,98 @@
+/** @jsxImportSource @emotion/react */
+import styled from '@emotion/styled';
+import { PaddingSize, } from '../../layout';
+import { KeyOfPalette, KeyOfTypo } from '../../theme';
+import { Padding, FlexBox } from '../../layout';
+import { CSSProperties } from 'react';
+import { css } from '@emotion/react';
+import { ReactNode } from 'react';
+import { Text } from '../Text';
+import { TextPropsKey } from '../Text';
+import { TextProps } from './../Text/index';
+import { typo } from '../../theme/typo';
+import { theme } from '../../theme';
+
+export interface ListHeaderProps {
+    title:string,
+    description: string;
+    varient?: ListHeaderVarient;
+}
+
+type ListHeaderVarient =
+  | 'listHeader_18'
+  | 'listHeader_20'
+  | 'listHeader_24'
+  | 'listHeader_28';
+
+type ListHeaderPaddingType = {
+    [key in ListHeaderVarient]: 
+        [number,number,number,number];
+}
+
+type ListHeaderTextType = {
+    [key in ListHeaderVarient]: {
+        [key in TextPropsKey]: any;
+    };
+};
+
+const listHeaderText: ListHeaderTextType = {
+    'listHeader_18' : {
+        typo : 'Text_18_SB',
+        color : 'black',
+    },
+    'listHeader_20' : {
+        typo : 'Header_20',
+        color : 'black',
+    },
+    'listHeader_24' : {
+        typo : 'Header_24',
+        color : 'black',
+    },
+    'listHeader_28' : {
+        typo : 'Header_28',
+        color : 'black',
+    },
+}
+
+
+const listHeaderPadding: ListHeaderPaddingType = {
+    'listHeader_18' : [32, 24, 12, 24],
+    'listHeader_20': [32, 24, 16, 24],
+    'listHeader_24': [32, 24, 16, 24],
+    'listHeader_28' : [32, 24, 20, 24],
+}
+
+
+export const TagBtnStyle = styled.button`
+  height: 26px;
+  width: 45px;
+  background: #EBECF0;
+  padding: 2px 0px;
+  align-items: right;
+`;
+
+
+export const ListHeader = ({
+    description = '제목에 대한 설명이 들어가는 자리입니다. 이런식으로 두줄로 쓸 수 있습니다.',
+    varient = 'listHeader_24',
+    title='큰 제목',
+}: ListHeaderProps) => {
+    return (
+        <Wrapper>
+            <Padding size = {listHeaderPadding[varient]}>
+                <FlexBox align='left'
+                     gap={description ? '10' : '0'}
+                     justify='center'
+                     direction='column'>
+                    <Text typo = {listHeaderText[varient].typo} color = {listHeaderText[varient].color}>{title}</Text>
+                    {description ? <Text typo = 'Text_16' color = 'gray_500'>{description}</Text> : <></>}
+                </FlexBox>
+            </Padding>
+        </Wrapper>
+    );
+};
+
+
+const Wrapper = styled.div`
+  background: ${({ theme }) => theme.palette.gradient.linear_white};
+`;

--- a/shared/ui/src/components/ListHeader/index.tsx
+++ b/shared/ui/src/components/ListHeader/index.tsx
@@ -1,16 +1,9 @@
 /** @jsxImportSource @emotion/react */
 import styled from '@emotion/styled';
-import { PaddingSize, } from '../../layout';
-import { KeyOfPalette, KeyOfTypo } from '../../theme';
 import { Padding, FlexBox } from '../../layout';
-import { CSSProperties } from 'react';
-import { css } from '@emotion/react';
-import { ReactNode } from 'react';
 import { Text } from '../Text';
 import { TextPropsKey } from '../Text';
-import { TextProps } from './../Text/index';
-import { typo } from '../../theme/typo';
-import { theme } from '../../theme';
+
 
 export interface ListHeaderProps {
     title:string,

--- a/shared/ui/src/components/ListHeader/listHeader.stories.tsx
+++ b/shared/ui/src/components/ListHeader/listHeader.stories.tsx
@@ -1,0 +1,48 @@
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+import { ListHeader } from '.';
+
+export default {
+    title: "listHeader",
+    component: ListHeader,
+    argTypes: {},
+} as ComponentMeta<typeof ListHeader>;
+
+const Template: ComponentStory<typeof ListHeader> = (args) => (
+    <ListHeader {...args} />
+);
+
+
+export const listHeader_18 = Template.bind({});
+listHeader_18.args = {
+};
+
+export const listHeader_20 = Template.bind({});
+listHeader_20.args = {
+};
+
+export const listHeader_24 = Template.bind({});
+listHeader_24.args = {
+};
+
+export const listHeader_28 = Template.bind({});
+listHeader_28.args = {
+};
+
+// export const headerWithDescript = Template.bind({});
+// headerWithDescript.args = {
+//   children: (
+//     <>
+//         <Padding size = {[20, 0]}>
+//             <Text 
+//                 typo="Text_16"
+//                 color = "gray_500"
+//             >
+//                 제목에 대한 설명이 들어가는 자리입니다. 두 줄로 작성이 가능합니다.
+//             </Text>
+//       </Padding>
+//     </>
+//   ),
+//   varient: 'headerWithDescript',
+// };
+
+

--- a/shared/ui/src/components/ListHeader/listHeader.stories.tsx
+++ b/shared/ui/src/components/ListHeader/listHeader.stories.tsx
@@ -28,21 +28,4 @@ export const listHeader_28 = Template.bind({});
 listHeader_28.args = {
 };
 
-// export const headerWithDescript = Template.bind({});
-// headerWithDescript.args = {
-//   children: (
-//     <>
-//         <Padding size = {[20, 0]}>
-//             <Text 
-//                 typo="Text_16"
-//                 color = "gray_500"
-//             >
-//                 제목에 대한 설명이 들어가는 자리입니다. 두 줄로 작성이 가능합니다.
-//             </Text>
-//       </Padding>
-//     </>
-//   ),
-//   varient: 'headerWithDescript',
-// };
-
 

--- a/shared/ui/src/components/Text/index.tsx
+++ b/shared/ui/src/components/Text/index.tsx
@@ -10,6 +10,13 @@ export interface TextProps extends HTMLAttributes<HTMLSpanElement> {
   children: string;
 }
 
+export type TextPropsKey = 'typo' | 'color';
+/**
+ *
+ * @param typo: align-items 속성 (기본값 : center)
+ * @param color : justify-content 속성 (기본값 : center)
+ */
+
 export const Text = ({
   typo,
   as = 'span',

--- a/shared/ui/src/components/index.ts
+++ b/shared/ui/src/components/index.ts
@@ -1,3 +1,4 @@
 export * from './Button';
 export * from './ButtonSet';
 export * from './Text';
+export * from './ListHeader'


### PR DESCRIPTION
### Summary

- ListHeader component ui 작업입니다.

### Describe your changes
![image](https://user-images.githubusercontent.com/67894159/210706313-a1fd1523-5955-4620-801e-4bb5372aead2.png)
title, description을 자유롭게 작성할 수 있고 decription이 있다면 flex gap을 10을 주어 header와 자연스럽게 떨어지도록 작업했습니다. Listheader_20, 18 등을 선택하여 header의 사이즈를 자유롭게 바꿀 수 있습니다. 

### To Reviewers

issue와 action 처음써보는데 요렇게 풀리퀘 올리는게 맞는지..혹시 제가 더해야할부분 있다면 해놓겠습니다

### Related Issues

#24
