### PR TITLE
feat(ticket) : globalOverlay (바텀시트 + 모달 반응형) / 로그인 오버레이콘텐츠

### DIFF
--- a/apps/ticket/package.json
+++ b/apps/ticket/package.json
@@ -24,6 +24,7 @@
     "next-transpile-modules": "^10.0.0",
     "react": "18.2.0",
     "react-dom": "18.2.0",
+    "react-spring-bottom-sheet": "^3.4.1",
     "recoil": "^0.7.6",
     "typescript": "4.9.4"
   },

--- a/apps/ticket/pages/_app.tsx
+++ b/apps/ticket/pages/_app.tsx
@@ -9,6 +9,8 @@ import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import type { AppProps } from 'next/app';
 import { useState } from 'react';
 import { RecoilRoot } from 'recoil';
+import 'react-spring-bottom-sheet/dist/style.css';
+import GlobalOverlay from '@components/shared/overlay/GlobalOverlay';
 
 export default function App({ Component, pageProps }: AppProps) {
   const [queryClient] = useState(() => new QueryClient());
@@ -22,6 +24,7 @@ export default function App({ Component, pageProps }: AppProps) {
             <Global styles={globalStyle} />
             <Layout>
               <Component {...pageProps} />
+              <GlobalOverlay />
             </Layout>
           </Hydrate>
         </QueryClientProvider>

--- a/apps/ticket/src/components/home/Landing.tsx
+++ b/apps/ticket/src/components/home/Landing.tsx
@@ -1,9 +1,15 @@
 import { Button, ButtonSet, ListHeader } from '@dudoong/ui';
+import useGlobalOverlay from '@lib/hooks/useGlobalOverlay';
 import DDHead from '@lib/utils/NextHead';
 import { useRouter } from 'next/router';
 
 const Landing = () => {
   const router = useRouter();
+  const { openOverlay } = useGlobalOverlay();
+  const openLoginTest = () => {
+    openOverlay({ content: 'login' });
+  };
+
   return (
     <>
       <DDHead title="두둥!" />
@@ -11,7 +17,7 @@ const Landing = () => {
         <ListHeader title={'테스트페이지'} size="listHeader_28" />
 
         <ButtonSet varient="vertical">
-          <Button onClick={() => router.push('/home')}>홈</Button>
+          <Button onClick={openLoginTest}>로그인 열기</Button>
           <Button onClick={() => router.push('/mypage')}>마이페이지</Button>
         </ButtonSet>
       </main>

--- a/apps/ticket/src/components/shared/overlay/GlobalOverlay.tsx
+++ b/apps/ticket/src/components/shared/overlay/GlobalOverlay.tsx
@@ -1,0 +1,59 @@
+import { useResponsive } from '@dudoong/utils';
+import useGlobalOverlay from '@lib/hooks/useGlobalOverlay';
+import { overlayState } from '@store/globalOverlay';
+import { ReactNode } from 'react';
+import { BottomSheet } from 'react-spring-bottom-sheet';
+import { useRecoilValue } from 'recoil';
+import Login from './content/Login';
+import Modal from './Modal';
+
+export type GlobalSheetContentKey = 'login';
+
+export type GlobalSheetContentType = {
+  [key in GlobalSheetContentKey]: ReactNode;
+};
+
+const globalSheetContent = {
+  login: Login,
+};
+
+const GlobalOverlay = () => {
+  const overlay = useRecoilValue(overlayState);
+  const { isOpen, closeOverlay } = useGlobalOverlay();
+
+  if (!overlay) {
+    return null;
+  } else {
+    const Content = globalSheetContent[overlay.content];
+    return (
+      <OverlayBox open={isOpen} onDismiss={closeOverlay}>
+        <Content {...overlay.props} />
+      </OverlayBox>
+    );
+  }
+};
+
+export default GlobalOverlay;
+
+export interface OverlayBoxProps {
+  open: boolean;
+  onDismiss: () => void;
+  children: ReactNode;
+}
+const OverlayBox = ({ open, onDismiss, children }: OverlayBoxProps) => {
+  const { isPC } = useResponsive();
+
+  return (
+    <>
+      {isPC ? (
+        <Modal open={open} onDismiss={onDismiss}>
+          {children}
+        </Modal>
+      ) : (
+        <BottomSheet open={open} onDismiss={onDismiss}>
+          {children}
+        </BottomSheet>
+      )}
+    </>
+  );
+};

--- a/apps/ticket/src/components/shared/overlay/Modal.tsx
+++ b/apps/ticket/src/components/shared/overlay/Modal.tsx
@@ -1,0 +1,45 @@
+import { RoundBlock } from '@dudoong/ui';
+import styled from '@emotion/styled';
+import { OverlayBoxProps } from './GlobalOverlay';
+
+const Modal = ({ onDismiss, children }: OverlayBoxProps) => {
+  return (
+    <Wrapper>
+      <Overlay onClick={onDismiss} />
+      <RoundBlock padding={[16, 0]} css={{ zIndex: '10', width: '390px' }}>
+        {children}
+      </RoundBlock>
+    </Wrapper>
+  );
+};
+export default Modal;
+
+const Wrapper = styled.div`
+  @keyframes fadeIn {
+    from {
+      opacity: 0;
+    }
+    to {
+      opacity: 1;
+    }
+  }
+  animation: 0.1s ease-in forwards fadeIn;
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  z-index: 9;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+
+const Overlay = styled.div`
+  background-color: rgba(0, 0, 0, 0.7);
+  /* -webkit-backdrop-filter: blur(5px);
+backdrop-filter: blur(5px); */
+  position: absolute;
+  width: 100%;
+  height: 100%;
+`;

--- a/apps/ticket/src/components/shared/overlay/content/Login.tsx
+++ b/apps/ticket/src/components/shared/overlay/content/Login.tsx
@@ -1,0 +1,27 @@
+import { Button, ButtonSet, ListHeader, Text, theme } from '@dudoong/ui';
+import { css } from '@emotion/react';
+
+const Login = () => {
+  return (
+    <>
+      <ListHeader size="listHeader_20" title={'로그인이 필요해요'} />
+      <ButtonSet varient="sub" padding={[20, 24]}>
+        <>
+          <Button varient="kakao">카카오로 로그인하기</Button>
+          <button
+            css={css`
+              color: ${theme.palette.gray_300};
+              &:hover {
+                text-decoration: underline;
+              }
+            `}
+          >
+            <Text typo={'Text_16'}>또는, 회원가입하기</Text>
+          </button>
+        </>
+      </ButtonSet>
+    </>
+  );
+};
+
+export default Login;

--- a/apps/ticket/src/lib/hooks/useGlobalOverlay.ts
+++ b/apps/ticket/src/lib/hooks/useGlobalOverlay.ts
@@ -1,0 +1,28 @@
+import { useResponsive } from '@dudoong/utils';
+import { overlayState, OverlayStateType } from '@store/globalOverlay';
+import { useRecoilState } from 'recoil';
+
+const useGlobalOverlay = () => {
+  const [overlay, setOverlay] = useRecoilState(overlayState);
+  const { isPC } = useResponsive();
+  const openOverlay = ({ content, props, isOpen = true }: OverlayStateType) => {
+    setOverlay({ content, props, isOpen });
+  };
+
+  const closeOverlay = () => {
+    setOverlay({ ...overlay!, isOpen: false });
+    if (isPC) {
+      setOverlay(null);
+    } else {
+      setTimeout(() => {
+        setOverlay(null);
+      }, 400);
+    }
+  };
+
+  const isOpen = overlay?.isOpen || false;
+
+  return { isOpen, openOverlay, closeOverlay };
+};
+
+export default useGlobalOverlay;

--- a/apps/ticket/src/store/globalOverlay.ts
+++ b/apps/ticket/src/store/globalOverlay.ts
@@ -1,0 +1,13 @@
+import { GlobalSheetContentKey } from '@components/shared/overlay/GlobalOverlay';
+import { atom } from 'recoil';
+
+export interface OverlayStateType {
+  content: GlobalSheetContentKey;
+  props?: any;
+  isOpen?: boolean;
+}
+
+export const overlayState = atom<OverlayStateType | null>({
+  key: 'overlayState',
+  default: null,
+});

--- a/shared/ui/src/components/Button/index.tsx
+++ b/shared/ui/src/components/Button/index.tsx
@@ -31,7 +31,7 @@ const TEXT_COLOR = {
     selected: `${theme.palette.white}`,
     unselected: `${theme.palette.main_500}`,
     alert: `${theme.palette.white}`,
-    kakao: `${theme.palette.gray_500}`,
+    kakao: `${theme.palette.black}`,
   },
 };
 

--- a/shared/ui/src/components/ButtonSet/index.tsx
+++ b/shared/ui/src/components/ButtonSet/index.tsx
@@ -7,7 +7,7 @@ import { FlexBox, flexboxPropsKey, Padding, PaddingSize } from '../../layout';
 export interface ButtonSetProps {
   children: ReactNode;
   varient?: ButtonSetVarient;
-  paddingSize?: PaddingSize;
+  padding?: PaddingSize;
 }
 
 type ButtonSetVarient =
@@ -66,11 +66,11 @@ const buttonSetFlex: buttonSetFlexType = {
 export const ButtonSet = ({
   children,
   varient = 'mono',
-  paddingSize = [40, 24, 20, 24],
+  padding = [40, 24, 20, 24],
 }: ButtonSetProps) => {
   return (
     <Wrapper>
-      <Padding size={paddingSize}>
+      <Padding size={padding}>
         <FlexBox
           align={buttonSetFlex[varient].align}
           gap={buttonSetFlex[varient].gap}

--- a/shared/ui/src/layout/Padding.tsx
+++ b/shared/ui/src/layout/Padding.tsx
@@ -1,9 +1,9 @@
 /** @jsxImportSource @emotion/react */
 import { css } from '@emotion/react';
-import { HTMLAttributes } from 'react';
+import { HTMLAttributes, ReactNode } from 'react';
 
 interface PaddingProps extends HTMLAttributes<HTMLDivElement> {
-  children: JSX.Element;
+  children: ReactNode;
   size?: PaddingSize;
   fill?: boolean;
 }

--- a/shared/ui/src/layout/RoundBlock/index.tsx
+++ b/shared/ui/src/layout/RoundBlock/index.tsx
@@ -2,6 +2,7 @@ import { Padding, PaddingSize } from '..';
 import { KeyOfPalette } from '../../theme';
 import styled from '@emotion/styled';
 import { CSSProperties } from '@emotion/serialize';
+import { HTMLAttributes, ReactNode } from 'react';
 
 /**
  * @param padding 패딩
@@ -12,8 +13,8 @@ import { CSSProperties } from '@emotion/serialize';
  * @param radius : border-radius 값
  */
 
-export interface RoundBlockProps {
-  children: JSX.Element;
+export interface RoundBlockProps extends HTMLAttributes<HTMLDivElement> {
+  children: ReactNode;
   color?: KeyOfPalette;
   padding?: PaddingSize;
   radius?: CSSProperties['borderRadius'];
@@ -24,9 +25,10 @@ export const RoundBlock = ({
   color = 'white',
   padding = [20, 20],
   radius = 16,
+  ...props
 }: RoundBlockProps) => {
   return (
-    <RoundWrapper radius={radius} colorKey={color} size={padding}>
+    <RoundWrapper radius={radius} colorKey={color} size={padding} {...props}>
       {children}
     </RoundWrapper>
   );

--- a/yarn.lock
+++ b/yarn.lock
@@ -1608,7 +1608,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:^7.0.0, @babel/runtime@npm:^7.10.2, @babel/runtime@npm:^7.11.2, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.16.3, @babel/runtime@npm:^7.17.8, @babel/runtime@npm:^7.18.3, @babel/runtime@npm:^7.18.9, @babel/runtime@npm:^7.5.0, @babel/runtime@npm:^7.7.6, @babel/runtime@npm:^7.8.4":
+"@babel/runtime@npm:^7.0.0, @babel/runtime@npm:^7.10.2, @babel/runtime@npm:^7.11.2, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.16.3, @babel/runtime@npm:^7.17.8, @babel/runtime@npm:^7.18.3, @babel/runtime@npm:^7.18.9, @babel/runtime@npm:^7.3.1, @babel/runtime@npm:^7.5.0, @babel/runtime@npm:^7.7.6, @babel/runtime@npm:^7.8.4":
   version: 7.20.7
   resolution: "@babel/runtime@npm:7.20.7"
   dependencies:
@@ -2722,6 +2722,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@juggle/resize-observer@npm:^3.2.0":
+  version: 3.4.0
+  resolution: "@juggle/resize-observer@npm:3.4.0"
+  checksum: 2505028c05cc2e17639fcad06218b1c4b60f932a4ebb4b41ab546ef8c157031ae377e3f560903801f6d01706dbefd4943b6c4704bf19ed86dfa1c62f1473a570
+  languageName: node
+  linkType: hard
+
 "@leichtgewicht/ip-codec@npm:^2.0.1":
   version: 2.0.4
   resolution: "@leichtgewicht/ip-codec@npm:2.0.4"
@@ -3013,6 +3020,33 @@ __metadata:
   version: 2.11.6
   resolution: "@popperjs/core@npm:2.11.6"
   checksum: 47fb328cec1924559d759b48235c78574f2d71a8a6c4c03edb6de5d7074078371633b91e39bbf3f901b32aa8af9b9d8f82834856d2f5737a23475036b16817f0
+  languageName: node
+  linkType: hard
+
+"@reach/portal@npm:^0.13.0":
+  version: 0.13.2
+  resolution: "@reach/portal@npm:0.13.2"
+  dependencies:
+    "@reach/utils": 0.13.2
+    tslib: ^2.1.0
+  peerDependencies:
+    react: ^16.8.0 || 17.x
+    react-dom: ^16.8.0 || 17.x
+  checksum: 319e0e9272b7dfbbe23b84188a4d25731d95eb71c424e83140e5c8cf98e0a2c8ad07b2a2d9e28e2f962e27d0c4fc3189891f51894379488fc31be381f455a471
+  languageName: node
+  linkType: hard
+
+"@reach/utils@npm:0.13.2":
+  version: 0.13.2
+  resolution: "@reach/utils@npm:0.13.2"
+  dependencies:
+    "@types/warning": ^3.0.0
+    tslib: ^2.1.0
+    warning: ^4.0.3
+  peerDependencies:
+    react: ^16.8.0 || 17.x
+    react-dom: ^16.8.0 || 17.x
+  checksum: 63b4f505c53c1043c8566b6c4f648dc84d9e1c33876783c0a5a5c8e51a90dcabdda06df98d1532b657905b24d4590ca51db7f2fd39dc336842c7cf80dbbbc6e2
   languageName: node
   linkType: hard
 
@@ -5217,6 +5251,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/warning@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@types/warning@npm:3.0.0"
+  checksum: 120dcf90600d583c68a60872200061eab9318ae15ea898581f8e9a6dc71b7941095dd81d8324e36d2a6006e5e12b6fc1cf8eda00cc514ee12bb39a912cc4e040
+  languageName: node
+  linkType: hard
+
 "@types/webpack-env@npm:^1.16.0":
   version: 1.18.0
   resolution: "@types/webpack-env@npm:1.18.0"
@@ -5586,6 +5627,25 @@ __metadata:
     "@webassemblyjs/ast": 1.11.1
     "@xtuc/long": 4.2.2
   checksum: f15ae4c2441b979a3b4fce78f3d83472fb22350c6dc3fd34bfe7c3da108e0b2360718734d961bba20e7716cb8578e964b870da55b035e209e50ec9db0378a3f7
+  languageName: node
+  linkType: hard
+
+"@xstate/react@npm:^1.2.0":
+  version: 1.6.3
+  resolution: "@xstate/react@npm:1.6.3"
+  dependencies:
+    use-isomorphic-layout-effect: ^1.0.0
+    use-subscription: ^1.3.0
+  peerDependencies:
+    "@xstate/fsm": ^1.0.0
+    react: ^16.8.0 || ^17.0.0
+    xstate: ^4.11.0
+  peerDependenciesMeta:
+    "@xstate/fsm":
+      optional: true
+    xstate:
+      optional: true
+  checksum: 88f4e798d2cfac85d552d5d7ec702fda1812082c5f8e7d944317a4f508f4e4de5aa2e927937004f7cb35e9c6947adaa3f7e3798a77872a3d3e606de05ba2720f
   languageName: node
   linkType: hard
 
@@ -6651,6 +6711,13 @@ __metadata:
     type-is: ~1.6.18
     unpipe: 1.0.0
   checksum: f1050dbac3bede6a78f0b87947a8d548ce43f91ccc718a50dd774f3c81f2d8b04693e52acf62659fad23101827dd318da1fb1363444ff9a8482b886a3e4a5266
+  languageName: node
+  linkType: hard
+
+"body-scroll-lock@npm:^3.1.5":
+  version: 3.1.5
+  resolution: "body-scroll-lock@npm:3.1.5"
+  checksum: 52c25b81d6e7a87cfbdd7870363c3e20a439dbc76535b735916e2df907abbce95c0da0d2c7a2cfe88f49775d53bbc4bd09445ffda2d61b999efa3f0b1dedfc5e
   languageName: node
   linkType: hard
 
@@ -9738,6 +9805,15 @@ __metadata:
   dependencies:
     tslib: ^1.9.3
   checksum: 3b25b06bb8e23a3a826a8eda89e547593a688486df531db92f6b767d96d397dc1efed4529ec3a44cb3ec1fbdd44abe50a30d0ce498f732501b36f5f18b619003
+  languageName: node
+  linkType: hard
+
+"focus-trap@npm:^6.2.2":
+  version: 6.9.4
+  resolution: "focus-trap@npm:6.9.4"
+  dependencies:
+    tabbable: ^5.3.3
+  checksum: 0b4cebcc11010bd9397731092bd59a981e838c710c6497374ba70571875a14ab27c0db7d60f36005ec01bdabc3b9cfeda11d30ddf5b8874596dcc95e18913b3b
   languageName: node
   linkType: hard
 
@@ -15606,7 +15682,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prop-types@npm:^15.0.0, prop-types@npm:^15.6.1, prop-types@npm:^15.7.2, prop-types@npm:^15.8.1":
+"prop-types@npm:^15.0.0, prop-types@npm:^15.5.8, prop-types@npm:^15.6.1, prop-types@npm:^15.7.2, prop-types@npm:^15.8.1":
   version: 15.8.1
   resolution: "prop-types@npm:15.8.1"
   dependencies:
@@ -16087,6 +16163,46 @@ __metadata:
   bin:
     react-scripts: bin/react-scripts.js
   checksum: 92afa2f245c7092ccc97d5609dc7a2130616262e34da7f15072d9442e2d2e1d4909a91022abd1faac1336eb17c5525a10d9bd43e1ae374c7ec941ca20addca68
+  languageName: node
+  linkType: hard
+
+"react-spring-bottom-sheet@npm:^3.4.1":
+  version: 3.4.1
+  resolution: "react-spring-bottom-sheet@npm:3.4.1"
+  dependencies:
+    "@juggle/resize-observer": ^3.2.0
+    "@reach/portal": ^0.13.0
+    "@xstate/react": ^1.2.0
+    body-scroll-lock: ^3.1.5
+    focus-trap: ^6.2.2
+    react-spring: ^8.0.27
+    react-use-gesture: ^8.0.1
+    xstate: ^4.15.1
+  peerDependencies:
+    react: ^16.14.0 || 17 || 18
+  checksum: c2f8b8af037a27c1d7b5a2fd1f495ccc690c6344164ae38fc762387aa060271af81073adccdfea9c24a356848b83910d3f4fa41e27c483df120a42146c9ea5c4
+  languageName: node
+  linkType: hard
+
+"react-spring@npm:^8.0.27":
+  version: 8.0.27
+  resolution: "react-spring@npm:8.0.27"
+  dependencies:
+    "@babel/runtime": ^7.3.1
+    prop-types: ^15.5.8
+  peerDependencies:
+    react: ">= 16.8.0"
+    react-dom: ">= 16.8.0"
+  checksum: 4f306e30c3a425fd2b11c265ca0a7c261de0f63c0250fa6fa19eddd58c50fc9eaa463927571ee1dec39659a1bf619aaacf3352602b7724695da240ec0bc106cf
+  languageName: node
+  linkType: hard
+
+"react-use-gesture@npm:^8.0.1":
+  version: 8.0.1
+  resolution: "react-use-gesture@npm:8.0.1"
+  peerDependencies:
+    react: ">= 16.8.0"
+  checksum: c8b2f34089c4108a6cd717802c930f32d127212333c384cd9d59a8e0f409d80da07e1974ba793977d86d31f88cea15aa36e5357204c062a75ad5a35647dbf723
   languageName: node
   linkType: hard
 
@@ -17946,6 +18062,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tabbable@npm:^5.3.3":
+  version: 5.3.3
+  resolution: "tabbable@npm:5.3.3"
+  checksum: 1aa56e1bb617cc10616c407f4e756f0607f3e2d30f9803664d70b85db037ca27e75918ed1c71443f3dc902e21dc9f991ce4b52d63a538c9b69b3218d3babcd70
+  languageName: node
+  linkType: hard
+
 "tailwindcss@npm:^3.0.2":
   version: 3.2.4
   resolution: "tailwindcss@npm:3.2.4"
@@ -18175,6 +18298,7 @@ __metadata:
     next-transpile-modules: ^10.0.0
     react: 18.2.0
     react-dom: 18.2.0
+    react-spring-bottom-sheet: ^3.4.1
     recoil: ^0.7.6
     typescript: 4.9.4
   languageName: unknown
@@ -18349,7 +18473,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tslib@npm:^2.0.0, tslib@npm:^2.0.1, tslib@npm:^2.0.3, tslib@npm:^2.4.0":
+"tslib@npm:^2.0.0, tslib@npm:^2.0.1, tslib@npm:^2.0.3, tslib@npm:^2.1.0, tslib@npm:^2.4.0":
   version: 2.4.1
   resolution: "tslib@npm:2.4.1"
   checksum: 19480d6e0313292bd6505d4efe096a6b31c70e21cf08b5febf4da62e95c265c8f571f7b36fcc3d1a17e068032f59c269fab3459d6cd3ed6949eafecf64315fca
@@ -18793,6 +18917,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"use-isomorphic-layout-effect@npm:^1.0.0":
+  version: 1.1.2
+  resolution: "use-isomorphic-layout-effect@npm:1.1.2"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: a6532f7fc9ae222c3725ff0308aaf1f1ddbd3c00d685ef9eee6714fd0684de5cb9741b432fbf51e61a784e2955424864f7ea9f99734a02f237b17ad3e18ea5cb
+  languageName: node
+  linkType: hard
+
+"use-subscription@npm:^1.3.0":
+  version: 1.8.0
+  resolution: "use-subscription@npm:1.8.0"
+  dependencies:
+    use-sync-external-store: ^1.2.0
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0
+  checksum: beac1f0ff14fe23fd6ae9c34681258936729f343bf6532bbce36caa8f4c1019ff380783e35b4aeb7f3faaec1a83af242d7833bf7e660816d24555dbdd2c934da
+  languageName: node
+  linkType: hard
+
 "use-sync-external-store@npm:^1.2.0":
   version: 1.2.0
   resolution: "use-sync-external-store@npm:1.2.0"
@@ -19010,7 +19157,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"warning@npm:^4.0.2":
+"warning@npm:^4.0.2, warning@npm:^4.0.3":
   version: 4.0.3
   resolution: "warning@npm:4.0.3"
   dependencies:
@@ -19768,6 +19915,13 @@ __metadata:
   version: 2.2.0
   resolution: "xmlchars@npm:2.2.0"
   checksum: 8c70ac94070ccca03f47a81fcce3b271bd1f37a591bf5424e787ae313fcb9c212f5f6786e1fa82076a2c632c0141552babcd85698c437506dfa6ae2d58723062
+  languageName: node
+  linkType: hard
+
+"xstate@npm:^4.15.1":
+  version: 4.35.2
+  resolution: "xstate@npm:4.35.2"
+  checksum: fe34d02b33745b36579c45924a7bcfc7ec819379aa8c4fc21e8a87eecee9e1b0885eba56f72e6bda08f3e5931f35741c81268fe4275a6bceaa5d006949ce4e40
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Summary
<!-- PR의 요약(제목)을 적어주세요 -->
티켓 페이지 바텀시트, 모달 관련 컴포넌트

### Describe your changes
<!-- 작업내용을 적어주세요 -->
- 전역으로 관리되는 오버레이에 관한 작업입니다
- PC 너비일때는 모달로, 모바일 너비일때는 바텀시트로 열립니다.
- 리코일 전역 상태로 어떤 모달을 열건지 key와 prop을 넘겨주면, 그걸 받아서 렌더링합니다.
- prop에 any 어떻게없애지

### To Reviewers
<!-- 리뷰어에게 남기는 참고사항을 적어주세요 -->

### Related Issues
<!-- 예시) * resolves #71 -->
#16 
resolved #32 