### PR TITLE
feat(ui): counter limit prop 생성 및 아이콘 색 적용, 0처리 

### DIFF
--- a/shared/ui/src/components/Counter/index.tsx
+++ b/shared/ui/src/components/Counter/index.tsx
@@ -4,10 +4,12 @@ import styled from '@emotion/styled';
 import { useState } from 'react';
 import { Plus, Dash } from 'react-bootstrap-icons';
 import { theme } from '../../theme';
+
 export interface CounterProps {
   count: number;
   width?: number;
   hegiht?: number;
+  limit?: number;
   onClickPlus: () => void;
   onClickMinus: () => void;
 }
@@ -16,22 +18,30 @@ export const Counter = ({
   count = 1,
   width,
   hegiht,
+  limit = 10000,
   onClickPlus,
   onClickMinus,
 }: CounterProps) => {
   const [ticketNum, setTicketNum] = useState<number>(count);
   const handlePlusClick = () => {
-    setTicketNum(ticketNum + 1);
-    onClickPlus();
+    if (ticketNum < limit) {
+      setTicketNum(ticketNum + 1);
+      onClickPlus();
+    }
   };
   const handleMinusClick = () => {
-    if (ticketNum === 1) return;
+    if (ticketNum === 0) return;
     setTicketNum(ticketNum - 1);
     onClickMinus();
   };
   return (
-    <CounterWrapper width={width} height={hegiht}>
-      <ImgWrapper onClick={handleMinusClick}>
+    <CounterWrapper
+      width={width}
+      height={hegiht}
+      count={ticketNum}
+      limit={limit}
+    >
+      <ImgWrapper count={ticketNum} limit={limit} onClick={handleMinusClick}>
         <Dash
           css={{
             width: '24px',
@@ -44,7 +54,7 @@ export const Counter = ({
       <Text typo={'Text_18'} color={'gray_500'}>
         {ticketNum}
       </Text>
-      <ImgWrapper onClick={handlePlusClick}>
+      <ImgWrapper count={ticketNum} limit={limit} onClick={handlePlusClick}>
         <Plus
           css={{
             width: '24px',
@@ -58,18 +68,27 @@ export const Counter = ({
   );
 };
 
-const ImgWrapper = styled.div`
+const ImgWrapper = styled.div<{
+  count: number;
+  limit: number;
+}>`
   padding: 0 4px;
-  cursor: pointer;
+  cursor: ${({ count, limit }) => (count >= limit ? `default` : `pointer`)};
 `;
+
 const CounterWrapper = styled.div<{
   width?: number;
   height?: number;
+  count: number;
+  limit: number;
 }>`
   box-sizing: border-box;
-  border: 1px solid ${({ theme }) => theme.palette.gray_400};
+  border: 1px solid ${({ theme }) => theme.palette.gray_500};
   border-radius: 18px;
-
+  background-color: ${({ count, limit, theme }) =>
+    count >= limit || count === 0
+      ? theme.palette.gray_300
+      : theme.palette.white};
   height: ${({ height }) => (height ? `${height}px` : `36px`)};
   width: ${({ width }) => (width ? `${width}px` : '93px')};
 

--- a/shared/ui/src/components/Counter/index.tsx
+++ b/shared/ui/src/components/Counter/index.tsx
@@ -47,7 +47,10 @@ export const Counter = ({
             width: '24px',
             height: '24px',
             paddingTop: '3px',
-            fill: `${theme.palette.gray_500}`,
+            fill: `${
+              ticketNum === 0 ? theme.palette.gray_300 : theme.palette.gray_500
+            }`,
+            cursor: `${ticketNum === 0 ? `default` : `pointer`}`,
           }}
         />
       </ImgWrapper>
@@ -60,7 +63,12 @@ export const Counter = ({
             width: '24px',
             height: '24px',
             paddingTop: '3px',
-            fill: `${theme.palette.gray_500}`,
+            fill: `${
+              ticketNum >= limit
+                ? theme.palette.gray_300
+                : theme.palette.gray_500
+            }`,
+            cursor: `${ticketNum >= limit ? `default` : `pointer`}`,
           }}
         />
       </ImgWrapper>
@@ -73,7 +81,6 @@ const ImgWrapper = styled.div<{
   limit: number;
 }>`
   padding: 0 4px;
-  cursor: ${({ count, limit }) => (count >= limit ? `default` : `pointer`)};
 `;
 
 const CounterWrapper = styled.div<{
@@ -85,10 +92,6 @@ const CounterWrapper = styled.div<{
   box-sizing: border-box;
   border: 1px solid ${({ theme }) => theme.palette.gray_500};
   border-radius: 18px;
-  background-color: ${({ count, limit, theme }) =>
-    count >= limit || count === 0
-      ? theme.palette.gray_300
-      : theme.palette.white};
   height: ${({ height }) => (height ? `${height}px` : `36px`)};
   width: ${({ width }) => (width ? `${width}px` : '93px')};
 


### PR DESCRIPTION
limit prop을 추가하였으며 0이라는 value가 들어갔을 때는 버튼이 작동하지 않습니다.

### Related Issues
<!-- - close 뒤에 이슈달면 링크 걸리고 이슈 닫혀요 -->
- close #90 
### Describe your changes
- counter limit에 다다르거나 0개의 티켓을 선택할 경우 gray_300으로 색이 변경됩니다. (400 뭔가 너무 찐해보여서 300으로 했는데 400으로 해도 괜찮을거같아여)
- limit에 다다르면 cursor모양변경, 더이상 value값이 오르지 않음

### To Reviewers
참고화면입니다..
![수정완료!](https://user-images.githubusercontent.com/67894159/220814751-e282eb04-a37a-42f0-b3c7-62f24f13a9ad.gif)

