### PR TITLE
fix(admin) : 옵션적용된 티켓이 팔렸을 때, 삭제 비활성화

### DIFF
--- a/apps/admin/src/components/events/options/apply/OptionItem.tsx
+++ b/apps/admin/src/components/events/options/apply/OptionItem.tsx
@@ -2,14 +2,21 @@ import { useLocation } from 'react-router-dom';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import OptionApi from '@lib/apis/option/OptionApi';
 import { FlexBox, ListRow, TagButton, Padding } from '@dudoong/ui';
+import { useEffect } from 'react';
 
 export interface OptionItemProps {
   name: string;
   subText: string;
   OptionGroupId: number;
+  soldOptionGroupId: number[];
 }
 
-const OptionItem = ({ name, subText, OptionGroupId }: OptionItemProps) => {
+const OptionItem = ({
+  name,
+  subText,
+  OptionGroupId,
+  soldOptionGroupId,
+}: OptionItemProps) => {
   const { pathname } = useLocation();
   const eventId = pathname.split('/')[2];
   const queryClient = useQueryClient();
@@ -42,6 +49,7 @@ const OptionItem = ({ name, subText, OptionGroupId }: OptionItemProps) => {
           <TagButton
             text="삭제"
             color="warn"
+            disabled={soldOptionGroupId.includes(OptionGroupId) ? true : false}
             size="lg"
             onClick={handleRemoveClick}
           />

--- a/apps/admin/src/components/events/options/apply/OptionItem.tsx
+++ b/apps/admin/src/components/events/options/apply/OptionItem.tsx
@@ -3,22 +3,19 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import OptionApi from '@lib/apis/option/OptionApi';
 import { FlexBox, ListRow, TagButton, Padding } from '@dudoong/ui';
 import { useEffect } from 'react';
+import { useRecoilValue } from 'recoil';
+import { soldOptionState } from '@store/soldOption';
 
 export interface OptionItemProps {
   name: string;
   subText: string;
   OptionGroupId: number;
-  soldOptionGroupId: number[];
 }
 
-const OptionItem = ({
-  name,
-  subText,
-  OptionGroupId,
-  soldOptionGroupId,
-}: OptionItemProps) => {
+const OptionItem = ({ name, subText, OptionGroupId }: OptionItemProps) => {
   const { pathname } = useLocation();
   const eventId = pathname.split('/')[2];
+  const soldOptions = useRecoilValue(soldOptionState);
   const queryClient = useQueryClient();
   const { mutate: optionDeleteMutate } = useMutation(
     OptionApi.PATCH_OPTION_DELETE,
@@ -38,23 +35,25 @@ const OptionItem = ({
 
   return (
     <>
-      <FlexBox align="center" justify="space-between">
-        <ListRow
-          text={name}
-          textColor={['black', 'gray_400']}
-          subText={subText}
-          padding={[13.5, 23]}
-        />
-        <Padding size={[0, 24, 0, 0]}>
-          <TagButton
-            text="삭제"
-            color="warn"
-            disabled={soldOptionGroupId.includes(OptionGroupId) ? true : false}
-            size="lg"
-            onClick={handleRemoveClick}
+      {soldOptions && (
+        <FlexBox align="center" justify="space-between">
+          <ListRow
+            text={name}
+            textColor={['black', 'gray_400']}
+            subText={subText}
+            padding={[13.5, 23]}
           />
-        </Padding>
-      </FlexBox>
+          <Padding size={[0, 24, 0, 0]}>
+            <TagButton
+              text="삭제"
+              color="warn"
+              disabled={soldOptions.includes(OptionGroupId) ? true : false}
+              size="lg"
+              onClick={handleRemoveClick}
+            />
+          </Padding>
+        </FlexBox>
+      )}
     </>
   );
 };

--- a/apps/admin/src/components/events/options/apply/OptionList.tsx
+++ b/apps/admin/src/components/events/options/apply/OptionList.tsx
@@ -20,7 +20,6 @@ interface OptionListProps {
 
 const OptionList = ({ optionItems }: OptionListProps) => {
   console.log(optionItems);
-  const [soldOptions, setSoldOptions] = useRecoilState(soldOptionState);
 
   if (!optionItems?.length) {
     return (
@@ -73,7 +72,6 @@ const OptionList = ({ optionItems }: OptionListProps) => {
                             name={item.name}
                             subText={`${item.type}`}
                             OptionGroupId={item.optionGroupId}
-                            soldOptionGroupId={soldOptions}
                           />
                         </OptionItemContainer>
                         <Spacing size={16} />

--- a/apps/admin/src/components/events/options/apply/OptionList.tsx
+++ b/apps/admin/src/components/events/options/apply/OptionList.tsx
@@ -10,6 +10,7 @@ import styled from '@emotion/styled';
 import OptionItem from './OptionItem';
 import { Draggable, Droppable } from 'react-beautiful-dnd';
 import type { OptionGroupResponse } from '@lib/apis/option/optionType';
+import { DudoongOne } from '@assets/stickers';
 
 interface OptionListProps {
   optionItems: OptionGroupResponse[];
@@ -23,11 +24,16 @@ const OptionList = ({ optionItems }: OptionListProps) => {
         <div>
           <ListHeader padding={0} size="listHeader_18" title="옵션 목록" />
           <Spacing size={42} />
-          <OptionItemContainer>
-            <Padding size={[24, 12, 24, 12]}>
+
+          <DudoongOne />
+          <Padding size={[24, 124.5, 24, 124.5]}>
+            <Text typo="Text_16" color="gray_500">
+              두둥! 옵션을 생성해주세요.
+            </Text>
+          </Padding>
+          {/* <Padding size={[24, 12, 24, 12]}>
               <Text typo="P_Header_16_SB">옵션을 먼저 생성해주세요!</Text>
-            </Padding>
-          </OptionItemContainer>
+            </Padding> */}
         </div>
       </Wrapper>
     );

--- a/apps/admin/src/components/events/options/apply/OptionList.tsx
+++ b/apps/admin/src/components/events/options/apply/OptionList.tsx
@@ -11,6 +11,8 @@ import OptionItem from './OptionItem';
 import { Draggable, Droppable } from 'react-beautiful-dnd';
 import type { OptionGroupResponse } from '@lib/apis/option/optionType';
 import { DudoongOne } from '@assets/stickers';
+import { useRecoilState } from 'recoil';
+import { soldOptionState } from '@store/soldOption';
 
 interface OptionListProps {
   optionItems: OptionGroupResponse[];
@@ -18,19 +20,24 @@ interface OptionListProps {
 
 const OptionList = ({ optionItems }: OptionListProps) => {
   console.log(optionItems);
+  const [soldOptions, setSoldOptions] = useRecoilState(soldOptionState);
+
   if (!optionItems?.length) {
     return (
       <Wrapper>
         <div>
           <ListHeader padding={0} size="listHeader_18" title="옵션 목록" />
           <Spacing size={42} />
-
-          <DudoongOne />
-          <Padding size={[24, 124.5, 24, 124.5]}>
-            <Text typo="Text_16" color="gray_500">
-              두둥! 옵션을 생성해주세요.
-            </Text>
-          </Padding>
+          <div>
+            <FlexBox justify={'center'} direction={'column'}>
+              <DudoongOne />
+              <Padding size={[24, 80, 24, 80]}>
+                <Text typo="Text_16" color="gray_500">
+                  두둥! 티켓 옵션을 먼저 생성해주세요.
+                </Text>
+              </Padding>
+            </FlexBox>
+          </div>
           {/* <Padding size={[24, 12, 24, 12]}>
               <Text typo="P_Header_16_SB">옵션을 먼저 생성해주세요!</Text>
             </Padding> */}
@@ -66,6 +73,7 @@ const OptionList = ({ optionItems }: OptionListProps) => {
                             name={item.name}
                             subText={`${item.type}`}
                             OptionGroupId={item.optionGroupId}
+                            soldOptionGroupId={soldOptions}
                           />
                         </OptionItemContainer>
                         <Spacing size={16} />

--- a/apps/admin/src/components/events/options/apply/TicketListOption.tsx
+++ b/apps/admin/src/components/events/options/apply/TicketListOption.tsx
@@ -1,17 +1,46 @@
-import { ListHeader, Spacing, theme, Text, Divider } from '@dudoong/ui';
+import {
+  ListHeader,
+  Spacing,
+  theme,
+  Text,
+  Divider,
+  Padding,
+  FlexBox,
+} from '@dudoong/ui';
 import styled from '@emotion/styled';
+import { DudoongOne } from '@assets/stickers';
 import { useQuery } from '@tanstack/react-query';
 import { useLocation } from 'react-router-dom';
 import OptionDropArea from './OptionDropArea';
 import OptionApi from '@lib/apis/option/OptionApi';
+import { soldOptionState } from '@store/soldOption';
+import { useEffect, useState } from 'react';
+import { useRecoilState } from 'recoil';
 
 const TicketListOption = () => {
   const { pathname } = useLocation();
   const eventId = pathname.split('/')[2];
-
+  const [soldOptions, setSoldOptions] = useRecoilState(soldOptionState);
   const { data, isSuccess } = useQuery(['AppliedTicket', eventId], () =>
     OptionApi.GET_EVENTS_APPLIEDOPTIONGROUPS(eventId),
   );
+
+  useEffect(() => {
+    if (isSuccess && data?.appliedOptionGroups.length > 0) {
+      const parsingOption = new Set(
+        data.appliedOptionGroups
+          .map((item) => {
+            if (item.isSold == true)
+              return item.optionGroups.map((item) => item.optionGroupId);
+          })
+          .filter((element) => element)
+          .flat(),
+      );
+      const soldOption = [...parsingOption] as number[];
+      const newSoldOption = new Set([...soldOption, ...soldOptions]);
+      setSoldOptions([...newSoldOption]);
+    }
+  }, []);
 
   return (
     <Wrapper>
@@ -20,20 +49,35 @@ const TicketListOption = () => {
           <Spacing size={36} />
           <ListHeader padding={0} size="listHeader_18" title="티켓 목록" />
           <Spacing size={42} />
-
-          {data.appliedOptionGroups?.map((item) => (
-            <div key={item?.ticketItemId}>
-              <TicketItem key={item.ticketItemId}>
-                <Text typo={'P_Header_16_SB'}>{item.ticketName}</Text>
-                <Divider line={true} />
-                <OptionDropArea
-                  ticketItemId={item.ticketItemId}
-                  optionGroups={item.optionGroups}
-                />
-              </TicketItem>
-              <Spacing size={16} />
-            </div>
-          ))}
+          {data?.appliedOptionGroups.length === 0 ? (
+            <>
+              <Spacing size={10} />
+              <FlexBox justify={'center'} direction={'column'}>
+                <DudoongOne />
+                <Padding size={[23, 80, 24, 80]}>
+                  <Text typo="Text_16" color="gray_500">
+                    두둥! 티켓을 먼저 생성해주세요.
+                  </Text>
+                </Padding>
+              </FlexBox>
+            </>
+          ) : (
+            <>
+              {data.appliedOptionGroups?.map((item) => (
+                <div key={item?.ticketItemId}>
+                  <TicketItem key={item.ticketItemId}>
+                    <Text typo={'P_Header_16_SB'}>{item.ticketName}</Text>
+                    <Divider line={true} />
+                    <OptionDropArea
+                      ticketItemId={item.ticketItemId}
+                      optionGroups={item.optionGroups}
+                    />
+                  </TicketItem>
+                  <Spacing size={16} />
+                </div>
+              ))}{' '}
+            </>
+          )}
         </>
       )}
     </Wrapper>

--- a/apps/admin/src/components/events/options/apply/TicketListOption.tsx
+++ b/apps/admin/src/components/events/options/apply/TicketListOption.tsx
@@ -37,10 +37,10 @@ const TicketListOption = () => {
           .flat(),
       );
       const soldOption = [...parsingOption] as number[];
-      const newSoldOption = new Set([...soldOption, ...soldOptions]);
+      const newSoldOption = new Set([...soldOption, ...(soldOptions || [])]);
       setSoldOptions([...newSoldOption]);
     }
-  }, []);
+  }, [isSuccess]);
 
   return (
     <Wrapper>

--- a/apps/admin/src/components/events/options/apply/index.tsx
+++ b/apps/admin/src/components/events/options/apply/index.tsx
@@ -2,7 +2,7 @@ import ContentGrid from '@components/shared/layout/ContentGrid';
 import OptionApi from '@lib/apis/option/OptionApi';
 import useGlobalOverlay from '@lib/hooks/useGlobalOverlay';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import {
   DragDropContext,
   DropResult,
@@ -11,6 +11,8 @@ import {
 import { useLocation } from 'react-router-dom';
 import OptionList from './OptionList';
 import TicketListOption from './TicketListOption';
+import { useRecoilState } from 'recoil';
+import { soldOptionState } from '@store/soldOption';
 
 const ApplyOption = () => {
   const { pathname } = useLocation();

--- a/apps/admin/src/components/events/tickets/newtickets/TicketSelect.tsx
+++ b/apps/admin/src/components/events/tickets/newtickets/TicketSelect.tsx
@@ -68,7 +68,7 @@ const TicketSelect = ({
           payType === '유료티켓' ? '선착순' : '승인';
         },
       },
-      purchaseLimit: '',
+      purchaseLimit: 1,
       supplyCount: '',
       quantity: '',
       isQuantityPublic: true,

--- a/apps/admin/src/components/events/tickets/newtickets/input/PurchaseLimit.tsx
+++ b/apps/admin/src/components/events/tickets/newtickets/input/PurchaseLimit.tsx
@@ -4,7 +4,7 @@ import { Control, Controller, FieldValues } from 'react-hook-form';
 export const PurchaseLimit = ({
   control,
 }: {
-  control: Control<FieldValues, any>;
+  control: Control<FieldValues, number>;
 }) => {
   return (
     <FlexBox align="center" justify="space-between" style={{ width: '100%' }}>

--- a/apps/admin/src/lib/apis/option/optionType.ts
+++ b/apps/admin/src/lib/apis/option/optionType.ts
@@ -1,3 +1,5 @@
+import { AccountInfo } from "../../../../../ticket/src/lib/apis/cart/cartType";
+
 export type OptionGroupType = '객관식' | 'Y/N' | '주관식';
 
 export interface CreateTicketOptionRequest {
@@ -44,8 +46,19 @@ export interface GetAppliedOptionGroupsResponse {
   appliedOptionGroups: AppliedOptionGroupsResponse[];
 }
 
+
+
 export interface AppliedOptionGroupsResponse {
   ticketItemId: number;
+  payType: string;
   ticketName: string;
+  description: string;
+  approveType: string;
+  purchaseLimit: number;
+  supplyCount: number;
+  quantity: number;
+  isQuantityPublic: boolean;
+  accountInfo: AccountInfo;
+  isSold: boolean;
   optionGroups: OptionGroupResponse[];
 }

--- a/apps/admin/src/store/soldOption.ts
+++ b/apps/admin/src/store/soldOption.ts
@@ -1,0 +1,6 @@
+import { atom } from "recoil";
+
+export const soldOptionState = atom<number[]>({
+    key: 'soldOptions',
+    default : [],
+})

--- a/apps/admin/src/store/soldOption.ts
+++ b/apps/admin/src/store/soldOption.ts
@@ -1,6 +1,6 @@
-import { atom } from "recoil";
+import { atom } from 'recoil';
 
-export const soldOptionState = atom<number[]>({
-    key: 'soldOptions',
-    default : [],
-})
+export const soldOptionState = atom<number[] | null>({
+  key: 'soldOptions',
+  default: null,
+});


### PR DESCRIPTION
### Related Issues
https://www.notion.so/9yujin/QA-eecc64017c4a4f29867271e6b700c0bb?p=bfa33fd72e0c4e1baa9a3afcbb4c224a&pm=s
### Describe your changes
옵션이 적용된 티켓이 구매완료되었을때 옵션 삭제가 비활성화됩니다. 

### To Reviewers
맨 처음 랜더링할때 옵션 삭제 버튼이 비활성화가 안되게 보여요.. useEffect가 처음에 안돌아가서 그런 건데
어떻게 고치면 좋을지 의견내주시면 감사드리겠습니다 ..
recoil로 하위 컴포넌트에서 가져온 팔린 티켓에 대한 옵션목록을 관리하는 형식입니다.

무료티켓 Error처리는 백엔드 나오자마자 하겠습니다!! 

