### PR TITLE
feat : next image | module exports 에서 devicesizes , imagesizes 구간 나누기

### DIFF
--- a/apps/ticket/next.config.js
+++ b/apps/ticket/next.config.js
@@ -31,6 +31,8 @@ module.exports = withBundleAnalyzer(
         return config;
       },
       images: {
+        imageSizes: [32, 64, 128, 256, 384],
+        deviceSizes: [750, 1080, 1920, 3840],
         domains: ['asset.dudoong.com'],
         minimumCacheTTL: 5184000,
       },


### PR DESCRIPTION
### Related Issues
<!-- - close 뒤에 이슈달면 링크 걸리고 이슈 닫혀요 -->
- close
### Describe your changes
<!-- 작업내용을 적어주세요 -->

### To Reviewers
<!-- 리뷰어에게 남기는 참고사항을 적어주세요 -->



https://fe-developers.kakaoent.com/2022/220714-next-image/
![무제](https://github.com/user-attachments/assets/6d9aa890-e8d2-447f-b045-17e4672743ee)







https://nextjs.org/docs/app/api-reference/components/image#devicesizes
https://nextjs.org/docs/app/api-reference/components/image#imagesizes


두 문서를 참고해서, 너무 많이 있으면 그만큼 메모리 더 쓸것 같으니 줄여서 배포 해보겠습니다 



