### PR TITLE
fix: 401 리프레시 실패 시 쿠키 삭제 + 로그인 리다이렉트

### DIFF
--- a/apps/ticket/pages/_app.tsx
+++ b/apps/ticket/pages/_app.tsx
@@ -120,8 +120,11 @@ MyApp.getInitialProps = async (context: AppContext) => {
       );
     } else throw new Error('isClient');
   } catch (err: any) {
-    //console.log(err.response);
     loginData = null;
+    ctx.res?.setHeader('set-cookie', [
+      'refreshToken=; path=/; max-age=0',
+      'accessToken=; path=/; max-age=0',
+    ]);
   }
 
   if (Component.getInitialProps) {

--- a/apps/ticket/src/lib/apis/axios.ts
+++ b/apps/ticket/src/lib/apis/axios.ts
@@ -5,7 +5,7 @@ import axios, {
   AxiosRequestConfig,
   isAxiosError,
 } from 'axios';
-import { getCookie, setCookie } from 'cookies-next';
+import { getCookie, setCookie, removeCookies } from 'cookies-next';
 import { UserApi } from './user/UserApi';
 
 export const axiosPrivate = axios.create({
@@ -22,28 +22,38 @@ axiosPrivate.interceptors.response.use(
     const origin = error.config as AxiosRequestConfig;
 
     if (status === 401) {
-      const refreshToken = getCookie('refreshToken');
-      const refresh = await AuthApi.REFRESH(String(refreshToken));
+      try {
+        const refreshToken = getCookie('refreshToken');
+        const refresh = await AuthApi.REFRESH(String(refreshToken));
 
-      const cookieString = `refreshToken=${refresh.refreshToken}; path=/; max-age=${refresh.refreshTokenAge}; secure=true; SameSite=None;`;
-      axiosPrivate.defaults.headers.Cookie = cookieString;
-      (origin.headers as AxiosHeaders).set('set-cookie', cookieString);
-      setCookie('refreshToken', refresh.refreshToken, {
-        maxAge: refresh.refreshTokenAge,
-        sameSite: 'none',
-        secure: true,
-        path: '/',
-      });
+        const cookieString = `refreshToken=${refresh.refreshToken}; path=/; max-age=${refresh.refreshTokenAge}; secure=true; SameSite=None;`;
+        axiosPrivate.defaults.headers.Cookie = cookieString;
+        (origin.headers as AxiosHeaders).set('set-cookie', cookieString);
+        setCookie('refreshToken', refresh.refreshToken, {
+          maxAge: refresh.refreshTokenAge,
+          sameSite: 'none',
+          secure: true,
+          path: '/',
+        });
 
-      axiosPrivate.defaults.headers.common[
-        'Authorization'
-      ] = `Bearer ${refresh.accessToken}`;
-      (origin.headers as AxiosHeaders).set(
-        'Authorization',
-        `Bearer ${refresh.accessToken}`,
-      );
+        axiosPrivate.defaults.headers.common[
+          'Authorization'
+        ] = `Bearer ${refresh.accessToken}`;
+        (origin.headers as AxiosHeaders).set(
+          'Authorization',
+          `Bearer ${refresh.accessToken}`,
+        );
 
-      return axios(origin);
+        return axios(origin);
+      } catch {
+        axiosPrivate.defaults.headers.common['Authorization'] = '';
+        removeCookies('accessToken');
+        removeCookies('refreshToken');
+        if (typeof window !== 'undefined') {
+          window.location.href = '/login';
+        }
+        return Promise.reject(error);
+      }
     }
     return Promise.reject(error);
   },


### PR DESCRIPTION
## Summary

스테이징 로그인 후 라이브 접속 시 앱 먹통 현상 수정.

- **axios 인터셉터** (`axios.ts`): 401 → 토큰 갱신 실패 시 쿠키 전부 삭제 + `/login` 리다이렉트
- **SSR** (`_app.tsx`): `getInitialProps` 리프레시 실패 시 `set-cookie`로 쿠키 만료 처리

### 변경 전
- 인터셉터: 리프레시 실패 시 에러만 전파 → 앱 먹통
- SSR: 실패 시 `loginData = null`만 설정, 쿠키 그대로 → 매 요청마다 반복 실패

### 변경 후
- 인터셉터: 리프레시 실패 → 쿠키 삭제 → `/login` 이동
- SSR: 실패 → 쿠키 만료 헤더 전송 → 다음 요청은 깨끗한 상태

close #329

## Test plan

- [ ] 스테이징 로그인 → 라이브 접속 → 먹통 없이 로그인 페이지로 이동 확인
- [ ] 라이브 로그인 → 정상 토큰 갱신 동작 확인
- [ ] 토큰 만료 후 자동 갱신 → 성공 시 기존 동작 유지 확인
- [ ] 토큰 만료 + 리프레시 실패 → 쿠키 삭제 + 로그인 리다이렉트 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)